### PR TITLE
fix figure reference

### DIFF
--- a/slides/boosting/slides-boosting-lgm-ctbm.tex
+++ b/slides/boosting/slides-boosting-lgm-ctbm.tex
@@ -4,7 +4,7 @@
 \input{../../latex-math/ml-ensembles.tex}
 \input{../../latex-math/ml-trees.tex}
 
-\newcommand{\titlefigure}{figure_man/split-finding02.png}
+\newcommand{\titlefigure}{figure/split_finding_2.png}
 \newcommand{\learninggoals}{
   \item \textcolor{blue}{XXX}
   \item \textcolor{blue}{XXX}


### PR DESCRIPTION
I noticed this while working on #819. I am assuming this is the figure that should be referenced? `figure_man/split-finding02.png` does not exist.