### PR TITLE
Fixed small notation error on slides

### DIFF
--- a/slides/evaluation/slides-evaluation-roccurves.tex
+++ b/slides/evaluation/slides-evaluation-roccurves.tex
@@ -190,7 +190,7 @@ Estimated posterior probabilities can change!
 
 Remember: Both probabilistic and scoring classifiers can output classes by 
 thresholding:
-$$\hx = [\pix) \ge c] \quad \text{ or } \quad \hx = [\fx \ge c_f].$$
+$$\hx = [\pix \ge c] \quad \text{ or } \quad \hx = [\fx \ge c_f].$$
 
 % \begin{center}
 %   \includegraphics{../supervised-classification/figure_man/classifiers.png}


### PR DESCRIPTION
Fixed this issue: https://github.com/slds-lmu/lecture_i2ml/issues/1059 [Slide 5/16]