### PR TITLE
Python environment

### DIFF
--- a/exercises/python-i2ml.yml
+++ b/exercises/python-i2ml.yml
@@ -1,0 +1,14 @@
+name: python-i2ml
+channels:
+  - defaults
+dependencies:
+  - python=3.10
+  - pandas
+  - numpy==1.21.5
+  - scipy==1.7.3
+  - scikit-learn==1.1.3
+  - seaborn
+  - statsmodels
+  - ipykernel
+  - notebook
+

--- a/exercises/supervised-classification/sol_classification_2_py.ipynb
+++ b/exercises/supervised-classification/sol_classification_2_py.ipynb
@@ -493,9 +493,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python-i2ml",
    "language": "python",
-   "name": "python3"
+   "name": "python-i2ml"
   },
   "language_info": {
    "codemirror_mode": {

--- a/exercises/supervised-regression/sol_regression_py.ipynb
+++ b/exercises/supervised-regression/sol_regression_py.ipynb
@@ -967,9 +967,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python-i2ml",
    "language": "python",
-   "name": "python3"
+   "name": "python-i2ml"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Changed Kernel name for 
- exercises/supervised-regression/sol_regression_py.ipynb
- exercises/supervised-classification/sol_classification_2_py.ipynb

according to Gobel environment: exercises/python-i2ml.yml

Note: all other notebooks have to be changed to this global environment as well. For the sakes of completeness also Aufgaben-Notebooks and Nested-Resampling, which are not yet merged with master branch.