### PR TITLE
Update classification_1 exercise sheet layout

### DIFF
--- a/exercises/supervised-classification/classification_1.qmd
+++ b/exercises/supervised-classification/classification_1.qmd
@@ -7,6 +7,7 @@ subtitle: "[Introduction to Machine Learning](https://slds-lmu.github.io/i2ml/)"
 ::: {.hidden}
 {{< include ../_quarto/latex-math.qmd >}}
 :::
+{{< include ../_quarto/solution-buttons.qmd >}}
 :::
 
 ## Exercise 1: Logistic vs softmax regression
@@ -24,10 +25,10 @@ $$
 \pi_k(\xv | \thetav) = \frac{\exp(\thetav_k^\top \xv)}{\sum_{j=1}^{g} \exp(\thetav_j^\top \xv)}, k \in \{1,...,g\}
 $$
 
-Show that logistic and softmax regression are equivalent for $g = 2$.
-
+a) Show that logistic and softmax regression are equivalent for $g = 2$.
 
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 As we would expect, the two formulations are equivalent (up to reparameterization). In order to see this, consider the softmax function components for both classes:
@@ -49,6 +50,7 @@ $$
 where $\thetav := \thetav_1 - \thetav_2$. Thus, we obtain the binary-case logistic function, reflecting that we only need one scoring function (and thus one set of parameters $\thetav$ rather than two $\thetav_1, \thetav_2$).
 </details> 
 :::
+:::
 
 ## Exercise 2: Hyperplanes
 
@@ -59,13 +61,14 @@ where $\thetav := \thetav_1 - \thetav_2$. Thus, we obtain the binary-case logist
 
 Linear classifiers like logistic regression learn a decision boundary that takes the form of a (linear) hyperplane. Hyperplanes are defined by equations $\thetav^\top \xv = b$ with coefficients $\thetav$ and a scalar $b \in \mathbb{R}$.
 
-In order to see that such expressions actually describe hyperplanes, consider $\thetav^\top \xv = \theta_0 + \theta_1 x_1 + \theta_2 x_2 = 0$. Sketch the hyperplanes given by the following coefficients and explain the difference between the parameterizations:
+a) In order to see that such expressions actually describe hyperplanes, consider $\thetav^\top \xv = \theta_0 + \theta_1 x_1 + \theta_2 x_2 = 0$. Sketch the hyperplanes given by the following coefficients and explain the difference between the parameterizations:
 
-- $\theta_0 = 0, \theta_1 = \theta_2 = 1$
-- $\theta_0 = 1, \theta_1 = \theta_2 = 1$
-- $\theta_0 = 0, \theta_1 = 1, \theta_2 = 2$
-  
+   - $\theta_0 = 0, \theta_1 = \theta_2 = 1$
+   - $\theta_0 = 1, \theta_1 = \theta_2 = 1$
+   - $\theta_0 = 0, \theta_1 = 1, \theta_2 = 2$
+     
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 
@@ -136,6 +139,7 @@ We see that a hyperplane is defined by the points that lie directly on it and th
 
 </details> 
 :::
+:::
 
 ## Exercise 3: Decision Boundaries & Thresholds in Logisitc Regression
 
@@ -145,19 +149,19 @@ We see that a hyperplane is defined by the points that lie directly on it and th
 :::
 
 In logistic regression (binary case), we estimate the probability $p(y = 1 | \xv, \thetav) = \pi(\xv | \thetav)$. In order to decide about
-the class of an observation, we set $\hat{y} = 1$ iff $\pi(\xv | \thetav) \geq \alpha\) for some \(\alpha \in (0, 1)$.
+the class of an observation, we set $\hat{y} = 1$ iff $\pi(\xv | \thetav) \geq \alpha$ for some $\alpha \in (0, 1)$.
 
-***
-Show that the decision boundary of the logistic classifier is a (linear) hyperplane. 
+a) Show that the decision boundary of the logistic classifier is a (linear) hyperplane. 
 
-<details> 
-<summary>*Hint*</summary>
-
-Derive the value of $\thx$ (depending on $\alpha$) starting from which you predict $\hat{y} = 1$ rather than $\hat{y} = 0$.
-
-</details>
+   <details> 
+   <summary>*Hint*</summary>
+   
+   Derive the value of $\thx$ (depending on $\alpha$) starting from which you predict $\hat{y} = 1$ rather than $\hat{y} = 0$.
+   
+   </details>
 
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 
@@ -175,12 +179,13 @@ $\thx = -\log \left(\frac{1}{\alpha} - 1 \right)$ is the equation of the linear 
 
 </details> 
 :::
+:::
 
-***
-Below you see the logistic function for a binary classification problem with two input features for different values $\thetav^\top = (\theta_1, \theta_2)^\top$ (plots 1-3) as well as $\alpha$ (plot 4). What can you deduce for the values of $\theta_1$, $\theta_2$, and $\alpha$? What are the implications for classification in the different scenarios?
+b) Below you see the logistic function for a binary classification problem with two input features for different values $\thetav^\top = (\theta_1, \theta_2)^\top$ (plots 1-3) as well as $\alpha$ (plot 4). What can you deduce for the values of $\theta_1$, $\theta_2$, and $\alpha$? What are the implications for classification in the different scenarios?
 
-```{r, echo=FALSE, fig.height=2, fig.width=3, message=FALSE, warning=FALSE}
-#| layout-nrow: 2
+::: {.content-visible when-format="html"}
+::: {.indent-1}
+```{r, include=FALSE, message=FALSE, warning=FALSE, eval=knitr::is_html_output()}
 suppressPackageStartupMessages(library(plotly))
 suppressPackageStartupMessages(library(tidyr))
 suppressPackageStartupMessages(library(dplyr))
@@ -189,7 +194,7 @@ suppressPackageStartupMessages(library(akima))
 options(warn=-1)
 
 # define x and different theta configurations
-seq_x <- seq(-10L, 10L, length.out = 100L)
+seq_x_vals <- seq(-10L, 10L, length.out = 100L)
 theta <- list(
   theta_1 = c(0.3, 0),
   theta_2 = c(0.3, 0.3),
@@ -237,9 +242,9 @@ plot_3d <- function(x, theta, eye = list(x = -1.5, y = 3L, z = 1L), plot_title) 
 # window" in the viewer pane) and save snapshot via the camera symbol without 
 # zooming
 
-p_1 <- plot_3d(seq_x, theta$theta_1, plot_title = "Plot (1)")
-p_2 <- plot_3d(seq_x, theta$theta_2, plot_title = "Plot (2)")
-p_3 <- plot_3d(seq_x, theta$theta_3, plot_title = "Plot (3)")
+p_1 <- plot_3d(seq_x_vals, theta$theta_1, plot_title = "Plot (1)")
+p_2 <- plot_3d(seq_x_vals, theta$theta_2, plot_title = "Plot (2)")
+p_3 <- plot_3d(seq_x_vals, theta$theta_3, plot_title = "Plot (3)")
 
 # add hyperplanes marking decision boundaries for different thresholds
 # use dirty trick with points, cannot get it to work with actual surface :]
@@ -296,29 +301,31 @@ plots <- list(p_1, p_2, p_3, p_4)
 names(plots) <- c("Plot (1)", "Plot (2)", "Plot (3)", "Plot (4)")
 ```
 
-```{r, echo=FALSE, fig.height=2, fig.width=3, message=FALSE, warning=FALSE}
-# Display the plots (only works with HTML output)
-if (knitr::is_html_output()) {
-  plots$`Plot (1)`
-  plots$`Plot (2)`
-  plots$`Plot (3)`
-  plots$`Plot (4)`
-}
+```{r, echo=FALSE, fig.height=2, fig.width=3, message=FALSE, warning=FALSE, eval=knitr::is_html_output(), include=knitr::is_html_output()}
+#| layout-nrow: 2
+plots$`Plot (1)`
+plots$`Plot (2)`
+plots$`Plot (3)`
+plots$`Plot (4)`
 ```
 
-::: {.content-hidden when-profile="html"}
+:::
+:::
+
+::: {.content-visible when-format="pdf"}
 ::: {layout-nrow=2}
-![](figure/logreg_1.png){fig-pos='H'}
+![](figure/logreg_1.png){fig-env="none"}
 
-![](figure/logreg_2.png){fig-pos='H'}
+![](figure/logreg_2.png){fig-env="none"}
 
-![](figure/logreg_3.png){fig-pos='H'}
+![](figure/logreg_3.png){fig-env="none"}
 
-![](figure/logreg_4.png){fig-pos='H'}
+![](figure/logreg_4.png){fig-env="none"}
 :::
 :::
 
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 
@@ -334,11 +341,12 @@ We observe
 
 </details> 
 :::
+:::
 
-***
-Derive the equation for the decision boundary hyperplane if we choose $\alpha = 0.5$.
+c) Derive the equation for the decision boundary hyperplane if we choose $\alpha = 0.5$.
 
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 We make use of our results from a):
@@ -356,15 +364,17 @@ The 0.5 threshold therefore leads to the coordinate hyperplane and divides the i
 
 </details> 
 :::
+:::
 
-***
-Explain when it might be sensible to set $\alpha$ to 0.5.
+d) Explain when it might be sensible to set $\alpha$ to 0.5.
 
 ::: {.content-visible when-profile="solution"}
+::: {.indent-1-sol}
 <details> 
 <summary>**Solution**</summary>
 
 When the threshold $\alpha = 0.5$ is chosen, the losses of misclassified observations, i.e., $L(\hat{y} = 0 ~|~ y = 1)$ and $L(\hat{y} = 1 ~|~ y = 0)$, are treated equally, which is often the intuitive thing to do. It means $\alpha = 0.5$ is a sensible threshold if we do not wish to avoid one type of misclassification more than the other. If, however, we need to be cautious to only predict class 1 if we are very confident (for example, when the decision triggers a costly therapy), it would make sense to set the threshold considerably higher.
 
 </details> 
+:::
 :::


### PR DESCRIPTION
Summary: Update the classification_1 exercise sheet to the new layout (QMD + rendered HTML).
Scope: `exercises/supervised-classification/classification_1.qmd`, `classification_1.html`.
Context: Changes were migrated from `update-exercise-sheet-layout` and split into a separate PR to avoid complications with Overleaf–GitHub integration.
